### PR TITLE
Close db connection after tests.

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,10 @@ var createStash = function(dbPath) {
 		this.connection = getConnection(this.dbPath);
 	};
 
+	Stash.prototype.close = function() {
+		this.connection.close();
+	};
+
 	Stash.prototype.create = function(data, callback) {
 		if (!data.id) data.id = uuid.v4();
 

--- a/test/magpie.js
+++ b/test/magpie.js
@@ -87,4 +87,8 @@ describe('Magpie', function() {
 			});
 		});
 	});
+
+	after(function() {
+		db.close();
+	})
 });


### PR DESCRIPTION
Mocha -w fails because the database connection wasn't being closed. I extended magpie with a close method that closes the current connection.
